### PR TITLE
Clear credentials when finished

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,3 +40,14 @@ EOF
 sh -c "aws cloudfront create-invalidation --distribution-id ${DISTRIBUTION_ID} \
           --paths '${SOURCE_PATH}' \
           --profile cloudfront-action $*"
+          
+# Clear out credentials after we're done.
+# We need to re-run `aws configure` with bogus input instead of
+# deleting ~/.aws in case there are other credentials living there.
+# https://forums.aws.amazon.com/thread.jspa?threadID=148833
+aws configure --profile cloudfront-action <<-EOF > /dev/null 2>&1
+null
+null
+null
+text
+EOF


### PR DESCRIPTION
This copies a change @jakejarvis made to the S3 sync action this action seems to be based on. It clears out AWS credentials when the action finishes, which improves the security.

https://github.com/jakejarvis/s3-sync-action/commit/0facb2201e4ea106a491c765ff0141dee4f9660b#diff-b958f585a04af5ee2087610ea7180f34R47-R56